### PR TITLE
feat: allow bigger spans

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "bmt-js",
+  "name": "@fairdatasociety/bmt-js",
   "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "bmt-js",
+      "name": "@fairdatasociety/bmt-js",
       "version": "2.0.1",
       "license": "MIT",
       "devDependencies": {

--- a/src/span.ts
+++ b/src/span.ts
@@ -1,4 +1,4 @@
-import { Bytes, Flavor } from './utils'
+import { Bytes, bytesToHex, Flavor } from './utils'
 
 export const DEFAULT_SPAN_SIZE = 8 as const
 
@@ -6,8 +6,8 @@ export interface Span<Length extends number = typeof DEFAULT_SPAN_SIZE>
   extends Bytes<Length>,
     Flavor<'Span'> {}
 
-// we limit the maximum span size in 32 bits to avoid BigInt compatibility issues
-export const MAX_SPAN_LENGTH = 2 ** 32 - 1
+// we limit the maximum span size to avoid BigInt compatibility issues
+export const MAX_SPAN_LENGTH = Number.MAX_SAFE_INTEGER
 
 /**
  * Create a span for storing the length of the chunk
@@ -30,9 +30,11 @@ export function makeSpan<Length extends number>(value: number, length?: Length):
   const span = new Uint8Array(spanLength)
   const dataView = new DataView(span.buffer)
   const littleEndian = true
-  const lengthLower32 = value & 0xffffffff
+  const hi32 = Math.floor(value / (2 ** 32))
+  const lo32 = value % (2 ** 32)
 
-  dataView.setUint32(0, lengthLower32, littleEndian)
+  dataView.setUint32(0, lo32, littleEndian)
+  dataView.setUint32(4, hi32, littleEndian)
 
   return span as Bytes<Length>
 }
@@ -40,5 +42,13 @@ export function makeSpan<Length extends number>(value: number, length?: Length):
 export function getSpanValue<Length extends number = 8>(span: Span<Length>): number {
   const dataView = new DataView(span.buffer)
 
-  return dataView.getUint32(0, true)
+  const lo32 = dataView.getUint32(0, true)
+  const hi32 = dataView.getUint32(4, true) * (2 ** 32)
+  const value = lo32 + hi32
+
+  if (value > Number.MAX_SAFE_INTEGER || value < 0) {
+    throw new Error(`invalid span value: ${bytesToHex(span, 16)}`)
+  }
+
+  return value
 }

--- a/test/unit/span.spec.ts
+++ b/test/unit/span.spec.ts
@@ -6,12 +6,15 @@ describe('span', () => {
     const chunkLengthBytes1 = makeSpan(4096)
     const chunkLength1 = getSpanValue(chunkLengthBytes1)
     expect(chunkLength1).toBe(4096)
+
     const chunkLengthBytes2 = makeSpan(MAX_SPAN_LENGTH)
     const chunkLength2 = getSpanValue(chunkLengthBytes2)
     expect(chunkLength2).toBe(MAX_SPAN_LENGTH)
+
     const chunkLengthBytes3 = makeSpan(1)
     const chunkLength3 = getSpanValue(chunkLengthBytes3)
     expect(chunkLength3).toBe(1)
-    expect(() => makeSpan(0)).toThrowError(/^invalid length for span: 0$/)
+
+    expect(() => makeSpan(-1)).toThrowError(/^invalid length for span: -1$/)
   })
 })


### PR DESCRIPTION
This change allows to use spans smaller than `Number.MAX_SAFE_INTEGER` which is about `2 ** 53 -1` instead of `2 ** 32 - 1`, thus allowing big files.